### PR TITLE
Add --time parameter support to owbm build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,14 @@ SRC_DIR := $(BASE_DIR)/srcs/$(SELECTED_TARGET)
 # 工具路径
 SCRIPT_DIR := $(BASE_DIR)/scripts
 CUSTOMIZE_TOOL := $(SCRIPT_DIR)/customize/customize
+BUILD_TIME_ARG :=
+ifneq ($(BUILD_TIME),)
+    ifeq ($(BUILD_TIME),1)
+        BUILD_TIME_ARG := --time
+    else
+        BUILD_TIME_ARG := --time=$(BUILD_TIME)
+    endif
+endif
 FEEDS_TOOL := $(SCRIPT_DIR)/feeds/feeds
 PM_INSTALL_TOOL := $(SCRIPT_DIR)/pm-install/pm-install
 INIT_TARGET_TOOL := $(SCRIPT_DIR)/init-target/init-target
@@ -118,7 +126,11 @@ install: check-target
 # 编译目标
 build: check-target
 	@echo "编译目标: $(SELECTED_TARGET)"
-	@$(CUSTOMIZE_TOOL) configs/$(SELECTED_TARGET)/customize.config -c build -s $(SRC_DIR)
+	@if [ -n "$(BUILD_TIME_ARG)" ]; then \
+		$(CUSTOMIZE_TOOL) configs/$(SELECTED_TARGET)/customize.config -c build -s $(SRC_DIR) "$(BUILD_TIME_ARG)"; \
+	else \
+		$(CUSTOMIZE_TOOL) configs/$(SELECTED_TARGET)/customize.config -c build -s $(SRC_DIR); \
+	fi
 	@ mkdir -p  configs/$(SELECTED_TARGET)/log
 	@time  make -C srcs/$(SELECTED_TARGET) -j$(BUILD_JOBS) V=s | tee configs/$(SELECTED_TARGET)/log/$(shell date +%Y%m%d_%H%M%S)_build.log
 	@echo "编译完成"
@@ -212,6 +224,7 @@ help:
 	@echo "  update      更新自定义软件包"
 	@echo "  install     安装软件包"
 	@echo "  build       编译目标"
+	@echo "  owbm build --time  编译并注入当前构建时间"
 	@echo "  copy        复制编译产物到指定路径"
 	@echo "  copy ID=<n> 复制指定序号的编译产物"
 	@echo "  copy M=<标记> 复制时添加标记目录"
@@ -231,6 +244,7 @@ help:
 	@echo "  make target=m28c all      # 为 m28c 执行完整构建"
 	@echo "  make menu                 # 显示菜单选择目标"
 	@echo "  make target=xr30 build    # 编译 xr30 目标"
+	@echo "  owbm build --time         # 编译并使用当前时间替换 __BUILD_TIME__"
 	@echo "  make wrt-menuconfig       # 在已选择的目标上执行menuconfig"
 	@echo "  make copy                 # 执行默认复制操作"
 	@echo "  make copy ID=1            # 执行序号1的复制规则"

--- a/owbm
+++ b/owbm
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ "$1" = "build" ]; then
+    shift
+    case "$1" in
+        --time)
+            shift
+            exec env BUILD_TIME=1 make build "$@"
+            ;;
+        --time=*)
+            build_time=${1#--time=}
+            shift
+            exec env "BUILD_TIME=$build_time" make build "$@"
+            ;;
+    esac
+
+    exec make build "$@"
+fi
+
+exec make "$@"

--- a/scripts/customize/customize.c
+++ b/scripts/customize/customize.c
@@ -18,6 +18,7 @@ void print_usage(const char *program_name) {
     printf("  -s, --src-dir <dir>  指定源码目录 (默认: 项目根目录/srcs)\n");
     printf("  -r, --res-dir <dir>  指定资源目录 (默认: 配置文件所在目录/res)\n");
     printf("  -a, --author <name>  指定作者名称 (默认从配置文件读取)\n");
+    printf("  -t, --time[=<time>]  指定构建时间（不指定值时使用当前时间）\n");
 }
 
 // 获取项目根目录
@@ -133,12 +134,14 @@ int main(int argc, char *argv[]) {
     char *src_dir = NULL;
     char *res_dir = NULL;
     char *author = NULL;
+    char *build_time = NULL;
     char *project_root = NULL;
     
     // 标记哪些指针是动态分配的
     bool src_dir_allocated = false;
     bool res_dir_allocated = false;
     bool author_allocated = false;
+    bool build_time_allocated = false;
     
     // 解析命令行参数
     static struct option long_options[] = {
@@ -147,11 +150,12 @@ int main(int argc, char *argv[]) {
         {"src-dir", required_argument, 0, 's'},
         {"res-dir", required_argument, 0, 'r'},
         {"author", required_argument, 0, 'a'},
+        {"time", optional_argument, 0, 't'},
         {0, 0, 0, 0}
     };
     
     int opt;
-    while ((opt = getopt_long(argc, argv, "hc:s:r:a:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hc:s:r:a:t::", long_options, NULL)) != -1) {
         switch (opt) {
             case 'h':
                 print_usage(argv[0]);
@@ -178,6 +182,24 @@ int main(int argc, char *argv[]) {
             case 'a':
                 author = optarg;
                 author_allocated = false;
+                break;
+
+            case 't':
+                if (optarg != NULL) {
+                    build_time = strdup(optarg);
+                    if (build_time == NULL) {
+                        log_error("错误: 分配构建时间失败");
+                        return 1;
+                    }
+                    build_time_allocated = true;
+                } else {
+                    build_time = get_current_time_str();
+                    if (build_time == NULL) {
+                        log_error("错误: 获取构建时间失败");
+                        return 1;
+                    }
+                    build_time_allocated = true;
+                }
                 break;
                 
             default:
@@ -241,6 +263,7 @@ int main(int argc, char *argv[]) {
         if (src_dir_allocated) free(src_dir);
         if (res_dir_allocated) free(res_dir);
         if (author_allocated) free(author);
+        if (build_time_allocated) free(build_time);
         return 1;
     }
     
@@ -251,11 +274,27 @@ int main(int argc, char *argv[]) {
         if (src_dir_allocated) free(src_dir);
         if (res_dir_allocated) free(res_dir);
         if (author_allocated) free(author);
+        if (build_time_allocated) free(build_time);
         return 0;
     }
     
     // 执行规则
-    int result = execute_rules(rules, rule_count, context, src_dir, res_dir, author, variables, var_count);
+    if (build_time == NULL) {
+        build_time = get_current_time_str();
+        if (build_time == NULL) {
+            log_error("错误: 获取构建时间失败");
+            free_rules_and_vars(rules, rule_count, variables, var_count);
+            free(project_root);
+            if (src_dir_allocated) free(src_dir);
+            if (res_dir_allocated) free(res_dir);
+            if (author_allocated) free(author);
+            return 1;
+        }
+        build_time_allocated = true;
+    }
+
+    int result = execute_rules(rules, rule_count, context, src_dir, res_dir, author,
+                               build_time, variables, var_count);
     
     // 释放内存
     free_rules_and_vars(rules, rule_count, variables, var_count);
@@ -263,6 +302,7 @@ int main(int argc, char *argv[]) {
     if (src_dir_allocated) free(src_dir);
     if (res_dir_allocated) free(res_dir);
     if (author_allocated) free(author);
+    if (build_time_allocated) free(build_time);
     
     return result;
 }

--- a/scripts/customize/customize.h
+++ b/scripts/customize/customize.h
@@ -44,7 +44,7 @@ int parse_customize_config(const char *filename, Rule **rules, int *rule_count,
 void free_rules_and_vars(Rule *rules, int rule_count, char **variables, int var_count);
 int execute_rules(Rule *rules, int rule_count, ContextType current_context, 
                   const char *src_dir, const char *res_dir, const char *author,
-                  char **variables, int var_count);
+                  const char *build_time, char **variables, int var_count);
 ContextType parse_context(const char *context_str);
 OperationType parse_operation(const char *operation_str);
 char* replace_variables(const char *str, const char *src_dir, const char *res_dir, 

--- a/scripts/customize/rules.c
+++ b/scripts/customize/rules.c
@@ -968,8 +968,7 @@ int execute_rule(const Rule *rule, const char *src_dir, const char *res_dir,
 // 执行所有规则
 int execute_rules(Rule *rules, int rule_count, ContextType current_context, 
                   const char *src_dir, const char *res_dir, const char *author,
-                  char **variables, int var_count) {
-    char *build_time = get_current_time_str();
+                  const char *build_time, char **variables, int var_count) {
     int success_count = 0;
     int fail_count = 0;
     
@@ -1003,8 +1002,6 @@ int execute_rules(Rule *rules, int rule_count, ContextType current_context,
             fail_count++;
         }
     }
-    
-    free(build_time);
     
     if (fail_count == 0) {
         log_info("所有规则执行成功 (%d 个)", success_count);


### PR DESCRIPTION
This pull request introduces a new `--time` parameter for the `owbm build` command, allowing users to specify a build time. Key changes include:

- **New `owbm` script**: A top-level POSIX wrapper script has been created to handle the `--time` parameter.
- **Makefile updates**: The Makefile has been modified to pass the specified time to the customization tool.
- **Customization tool adjustments**: The `customize.c` and related files have been updated to support the new parameter, allowing for both the current time and a user-defined time in the format `YYYY-MM-DD HH:MM:SS`.
- **Compatibility**: The implementation maintains compatibility with the existing Makefile behavior, defaulting to the current time if no argument is provided.

Note: While the parameter chain and script syntax have been validated, full compilation was not possible in the current Windows environment due to dependencies on Unix tools and `linux/limits.h`.